### PR TITLE
SetBootOrderOnce must ensure RebootPolicy is set to Terminate

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2328,8 +2328,9 @@ func (*Client) modifyVmBootOrder(vmCopy *kubevirtv1.VirtualMachine, bootTarget s
 	return nil
 }
 
-// SetBootOnce sets the boot source override to "Once" for the next boot
-// It saves the original boot configuration and VMI UID so it can be restored after reboot
+// SetBootOnce sets the boot source override to "Once" for the next boot.
+// It saves the original boot configuration, rebootPolicy and VMI UID so
+// they can be restored after reboot.
 func (c *Client) SetBootOnce(namespace, name, bootTarget string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
@@ -2384,15 +2385,20 @@ func (c *Client) SetBootOnce(namespace, name, bootTarget string) error {
 			}
 			annotations[BootOnceOriginalConfigAnnotation] = originalConfig
 			annotations[BootOnceVMIUIDAnnotation] = currentVMIUID
+			// Keep existing BootOnceOriginalRebootPolicyAnnotation — it
+			// already holds the real original value from the first SetBootOnce call.
 		}
 	} else {
-		// No existing boot-once - capture current boot order
+		// No existing boot-once — capture current boot order and rebootPolicy
 		originalConfig, err := c.captureCurrentBootOrder(vmCopy)
 		if err != nil {
 			return fmt.Errorf("failed to capture boot order: %w", err)
 		}
 		annotations[BootOnceOriginalConfigAnnotation] = originalConfig
 		annotations[BootOnceVMIUIDAnnotation] = currentVMIUID
+		if vmCopy.Spec.Template != nil && vmCopy.Spec.Template.Spec.Domain.RebootPolicy != nil {
+			annotations[BootOnceOriginalRebootPolicyAnnotation] = string(*vmCopy.Spec.Template.Spec.Domain.RebootPolicy)
+		}
 	}
 
 	// Add boot-once label for watch selector
@@ -2408,6 +2414,13 @@ func (c *Client) SetBootOnce(namespace, name, bootTarget string) error {
 	// Modify boot order to boot from target
 	if err := c.modifyVmBootOrder(vmCopy, bootTarget); err != nil {
 		return fmt.Errorf("failed to modify boot order: %w", err)
+	}
+
+	// Set rebootPolicy to Terminate so that KubeVirt destroys the VMI on
+	// guest-initiated reboot and we can detect the VMI UID change.
+	if vmCopy.Spec.Template != nil {
+		terminate := kubevirtv1.RebootPolicyTerminate
+		vmCopy.Spec.Template.Spec.Domain.RebootPolicy = &terminate
 	}
 
 	// Compute merge patch from changes (preserves unknown fields)
@@ -2943,8 +2956,9 @@ const BootOnceLabel = "redfish.boot.once"
 
 // BootOnceAnnotations are the annotation keys used for boot-once state
 const (
-	BootOnceOriginalConfigAnnotation = "redfish.boot.once.original-config"
-	BootOnceVMIUIDAnnotation         = "redfish.boot.once.vmi-uid"
+	BootOnceOriginalConfigAnnotation       = "redfish.boot.once.original-config"
+	BootOnceVMIUIDAnnotation               = "redfish.boot.once.vmi-uid"
+	BootOnceOriginalRebootPolicyAnnotation = "redfish.boot.once.original-reboot-policy"
 )
 
 // Import tracking labels
@@ -3269,6 +3283,23 @@ func (c *Client) handleVMUpdate(vm *kubevirtv1.VirtualMachine) {
 			return
 		}
 
+		// Read the saved original rebootPolicy before removing annotations
+		vmAnnotations := vmCopy.GetAnnotations()
+		originalRebootPolicy := ""
+		if vmAnnotations != nil {
+			originalRebootPolicy = vmAnnotations[BootOnceOriginalRebootPolicyAnnotation]
+		}
+
+		// Restore rebootPolicy on the typed VM
+		if vmCopy.Spec.Template != nil {
+			if originalRebootPolicy != "" {
+				policy := kubevirtv1.RebootPolicy(originalRebootPolicy)
+				vmCopy.Spec.Template.Spec.Domain.RebootPolicy = &policy
+			} else {
+				vmCopy.Spec.Template.Spec.Domain.RebootPolicy = nil
+			}
+		}
+
 		// Remove boot-once label and annotations
 		vmLabels := vmCopy.GetLabels()
 		if vmLabels != nil {
@@ -3276,10 +3307,10 @@ func (c *Client) handleVMUpdate(vm *kubevirtv1.VirtualMachine) {
 			vmCopy.SetLabels(vmLabels)
 		}
 
-		vmAnnotations := vmCopy.GetAnnotations()
 		if vmAnnotations != nil {
 			delete(vmAnnotations, BootOnceOriginalConfigAnnotation)
 			delete(vmAnnotations, BootOnceVMIUIDAnnotation)
+			delete(vmAnnotations, BootOnceOriginalRebootPolicyAnnotation)
 			delete(vmAnnotations, "redfish.boot.source.override.enabled")
 			delete(vmAnnotations, "redfish.boot.source.override.target")
 			delete(vmAnnotations, "redfish.boot.source.override.mode")
@@ -3309,7 +3340,7 @@ func (c *Client) handleVMUpdate(vm *kubevirtv1.VirtualMachine) {
 			return
 		}
 
-		logger.Info("Successfully restored boot order for VM %s/%s after VMI change", namespace, name)
+		logger.Info("Successfully restored boot order and rebootPolicy for VM %s/%s after VMI change", namespace, name)
 	}
 }
 

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2240,6 +2240,9 @@ func (c *Client) SetBootOrder(namespace, name, bootTarget string) error {
 		return err
 	}
 
+	// A permanent boot order change supersedes any pending boot-once state.
+	c.clearBootOnceState(vmCopy)
+
 	// Compute merge patch from changes (preserves unknown fields)
 	patch, err := computeVMPatch(vm, vmCopy)
 	if err != nil {
@@ -2999,6 +3002,43 @@ func isCDIManagedPod(pod *corev1.Pod) bool {
 	return hasCDI
 }
 
+// clearBootOnceState removes all boot-once labels, annotations and restores
+// the original rebootPolicy on the given VM copy. The caller is responsible
+// for computing a patch and applying it to the cluster.
+func (c *Client) clearBootOnceState(vmCopy *kubevirtv1.VirtualMachine) {
+	annotations := vmCopy.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+
+	originalRebootPolicy := annotations[BootOnceOriginalRebootPolicyAnnotation]
+
+	// Restore original rebootPolicy when a saved value exists
+	if vmCopy.Spec.Template != nil {
+		if originalRebootPolicy != "" {
+			policy := kubevirtv1.RebootPolicy(originalRebootPolicy)
+			vmCopy.Spec.Template.Spec.Domain.RebootPolicy = &policy
+		} else if annotations[BootOnceOriginalConfigAnnotation] != "" {
+			// Boot-once was active but the original had no rebootPolicy
+			vmCopy.Spec.Template.Spec.Domain.RebootPolicy = nil
+		}
+	}
+
+	delete(annotations, BootOnceOriginalConfigAnnotation)
+	delete(annotations, BootOnceVMIUIDAnnotation)
+	delete(annotations, BootOnceOriginalRebootPolicyAnnotation)
+	delete(annotations, "redfish.boot.source.override.enabled")
+	delete(annotations, "redfish.boot.source.override.target")
+	delete(annotations, "redfish.boot.source.override.mode")
+	vmCopy.SetAnnotations(annotations)
+
+	vmLabels := vmCopy.GetLabels()
+	if vmLabels != nil {
+		delete(vmLabels, BootOnceLabel)
+		vmCopy.SetLabels(vmLabels)
+	}
+}
+
 // BootOrderConfig represents the boot order configuration for a disk
 type BootOrderConfig struct {
 	DiskName  string `json:"diskName"`
@@ -3283,39 +3323,8 @@ func (c *Client) handleVMUpdate(vm *kubevirtv1.VirtualMachine) {
 			return
 		}
 
-		// Read the saved original rebootPolicy before removing annotations
-		vmAnnotations := vmCopy.GetAnnotations()
-		originalRebootPolicy := ""
-		if vmAnnotations != nil {
-			originalRebootPolicy = vmAnnotations[BootOnceOriginalRebootPolicyAnnotation]
-		}
-
-		// Restore rebootPolicy on the typed VM
-		if vmCopy.Spec.Template != nil {
-			if originalRebootPolicy != "" {
-				policy := kubevirtv1.RebootPolicy(originalRebootPolicy)
-				vmCopy.Spec.Template.Spec.Domain.RebootPolicy = &policy
-			} else {
-				vmCopy.Spec.Template.Spec.Domain.RebootPolicy = nil
-			}
-		}
-
-		// Remove boot-once label and annotations
-		vmLabels := vmCopy.GetLabels()
-		if vmLabels != nil {
-			delete(vmLabels, BootOnceLabel)
-			vmCopy.SetLabels(vmLabels)
-		}
-
-		if vmAnnotations != nil {
-			delete(vmAnnotations, BootOnceOriginalConfigAnnotation)
-			delete(vmAnnotations, BootOnceVMIUIDAnnotation)
-			delete(vmAnnotations, BootOnceOriginalRebootPolicyAnnotation)
-			delete(vmAnnotations, "redfish.boot.source.override.enabled")
-			delete(vmAnnotations, "redfish.boot.source.override.target")
-			delete(vmAnnotations, "redfish.boot.source.override.mode")
-			vmCopy.SetAnnotations(vmAnnotations)
-		}
+		// Remove boot-once state (label, annotations) and restore original rebootPolicy
+		c.clearBootOnceState(vmCopy)
 
 		// Compute merge patch from changes (preserves unknown fields)
 		patch, err := computeVMPatch(currentVM, vmCopy)

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -2501,6 +2501,19 @@ func TestSetBootOnce(t *testing.T) {
 				if annotations["redfish.boot.source.override.target"] != "Cd" {
 					t.Error("Expected redfish override target annotation to be 'Cd'")
 				}
+
+				// Original rebootPolicy annotation should be empty (VM had no policy set)
+				if annotations[BootOnceOriginalRebootPolicyAnnotation] != "" {
+					t.Errorf("Expected original reboot policy annotation to be empty, got '%s'", annotations[BootOnceOriginalRebootPolicyAnnotation])
+				}
+
+				// rebootPolicy should be set to Terminate
+				if vm.Spec.Template == nil || vm.Spec.Template.Spec.Domain.RebootPolicy == nil {
+					t.Fatal("Expected rebootPolicy to be set")
+				}
+				if *vm.Spec.Template.Spec.Domain.RebootPolicy != kubevirtv1.RebootPolicyTerminate {
+					t.Errorf("Expected rebootPolicy to be 'Terminate', got '%s'", *vm.Spec.Template.Spec.Domain.RebootPolicy)
+				}
 			},
 		},
 		{
@@ -2554,6 +2567,79 @@ func TestSetBootOnce(t *testing.T) {
 				if labels[BootOnceLabel] != "enabled" {
 					t.Errorf("Expected boot-once label to be 'enabled', got '%s'", labels[BootOnceLabel])
 				}
+
+				// rebootPolicy should be set to Terminate even when VM is off
+				if vm.Spec.Template == nil || vm.Spec.Template.Spec.Domain.RebootPolicy == nil {
+					t.Fatal("Expected rebootPolicy to be set")
+				}
+				if *vm.Spec.Template.Spec.Domain.RebootPolicy != kubevirtv1.RebootPolicyTerminate {
+					t.Errorf("Expected rebootPolicy to be 'Terminate', got '%s'", *vm.Spec.Template.Spec.Domain.RebootPolicy)
+				}
+			},
+		},
+		{
+			name:       "Set boot once preserves existing rebootPolicy in annotation",
+			bootTarget: "Cd",
+			setupVM: func(mockClient *MockDynamicClient) {
+				bootOrder1 := uint(1)
+				reboot := kubevirtv1.RebootPolicyReboot
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &reboot,
+									Devices: kubevirtv1.Devices{
+										Disks: []kubevirtv1.Disk{
+											{Name: "disk0", BootOrder: &bootOrder1},
+											{Name: "cdrom0", DiskDevice: kubevirtv1.DiskDevice{CDRom: &kubevirtv1.CDRomTarget{}}},
+										},
+									},
+								},
+								Volumes: []kubevirtv1.Volume{
+									{Name: "disk0", VolumeSource: kubevirtv1.VolumeSource{DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv0"}}},
+									{Name: "cdrom0", VolumeSource: kubevirtv1.VolumeSource{DataVolume: &kubevirtv1.DataVolumeSource{Name: "cdrom-dv"}}},
+								},
+							},
+						},
+					},
+				}
+				mockClient.AddVM(vm)
+			},
+			setupVMI: func(mockClient *MockDynamicClient) {
+				vmi := &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+						UID:       "vmi-uid-1",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Running,
+					},
+				}
+				mockClient.AddVMI(vmi)
+			},
+			validate: func(t *testing.T, mockClient *MockDynamicClient) {
+				vm, err := mockClient.GetVM("test-namespace", "test-vm")
+				if err != nil {
+					t.Fatalf("Failed to get VM: %v", err)
+				}
+
+				annotations := vm.GetAnnotations()
+				if annotations[BootOnceOriginalRebootPolicyAnnotation] != "Reboot" {
+					t.Errorf("Expected original reboot policy to be 'Reboot', got '%s'", annotations[BootOnceOriginalRebootPolicyAnnotation])
+				}
+
+				if vm.Spec.Template == nil || vm.Spec.Template.Spec.Domain.RebootPolicy == nil {
+					t.Fatal("Expected rebootPolicy to be set")
+				}
+				if *vm.Spec.Template.Spec.Domain.RebootPolicy != kubevirtv1.RebootPolicyTerminate {
+					t.Errorf("Expected rebootPolicy to be 'Terminate', got '%s'", *vm.Spec.Template.Spec.Domain.RebootPolicy)
+				}
 			},
 		},
 	}
@@ -2580,15 +2666,18 @@ func TestSetBootOnce(t *testing.T) {
 
 // TestHandleVMUpdate tests the handleVMUpdate function
 func TestHandleVMUpdate(t *testing.T) {
+	terminate := kubevirtv1.RebootPolicyTerminate
+
 	testCases := []struct {
-		name             string
-		setupVM          func(mockClient *MockDynamicClient)
-		setupVMI         func(mockClient *MockDynamicClient)
-		expectRestore    bool
-		expectClearState bool
+		name                 string
+		setupVM              func(mockClient *MockDynamicClient)
+		setupVMI             func(mockClient *MockDynamicClient)
+		expectRestore        bool
+		expectClearState     bool
+		expectedRebootPolicy *kubevirtv1.RebootPolicy
 	}{
 		{
-			name: "VMI UID changed - should restore boot order",
+			name: "VMI UID changed - should restore boot order and rebootPolicy",
 			setupVM: func(mockClient *MockDynamicClient) {
 				bootOrder1 := uint(1)
 				vm := &kubevirtv1.VirtualMachine{
@@ -2601,6 +2690,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Annotations: map[string]string{
 							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":1},{"diskName":"cdrom0","bootOrder":2}]`,
 							BootOnceVMIUIDAnnotation:               "old-vmi-uid",
+							BootOnceOriginalRebootPolicyAnnotation: "Reboot",
 							"redfish.boot.source.override.enabled": "Once",
 							"redfish.boot.source.override.target":  "Cd",
 						},
@@ -2609,6 +2699,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: kubevirtv1.VirtualMachineInstanceSpec{
 								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
 									Devices: kubevirtv1.Devices{
 										Disks: []kubevirtv1.Disk{
 											{Name: "disk0", BootOrder: &bootOrder1},
@@ -2637,6 +2728,63 @@ func TestHandleVMUpdate(t *testing.T) {
 			},
 			expectRestore:    true,
 			expectClearState: true,
+			expectedRebootPolicy: func() *kubevirtv1.RebootPolicy {
+				p := kubevirtv1.RebootPolicyReboot
+				return &p
+			}(),
+		},
+		{
+			name: "VMI UID changed, no original rebootPolicy - should remove rebootPolicy",
+			setupVM: func(mockClient *MockDynamicClient) {
+				bootOrder1 := uint(1)
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							BootOnceLabel: "enabled",
+						},
+						Annotations: map[string]string{
+							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":1}]`,
+							BootOnceVMIUIDAnnotation:               "old-vmi-uid",
+							BootOnceOriginalRebootPolicyAnnotation: "",
+							"redfish.boot.source.override.enabled": "Once",
+							"redfish.boot.source.override.target":  "Cd",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
+									Devices: kubevirtv1.Devices{
+										Disks: []kubevirtv1.Disk{
+											{Name: "disk0", BootOrder: &bootOrder1},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				mockClient.AddVM(vm)
+			},
+			setupVMI: func(mockClient *MockDynamicClient) {
+				vmi := &kubevirtv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+						UID:       "new-vmi-uid",
+					},
+					Status: kubevirtv1.VirtualMachineInstanceStatus{
+						Phase: kubevirtv1.Running,
+					},
+				}
+				mockClient.AddVMI(vmi)
+			},
+			expectRestore:        true,
+			expectClearState:     true,
+			expectedRebootPolicy: nil,
 		},
 		{
 			name: "VMI UID same - should not restore",
@@ -2651,6 +2799,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Annotations: map[string]string{
 							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":1}]`,
 							BootOnceVMIUIDAnnotation:               "same-vmi-uid",
+							BootOnceOriginalRebootPolicyAnnotation: "Reboot",
 							"redfish.boot.source.override.enabled": "Once",
 						},
 					},
@@ -2658,6 +2807,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: kubevirtv1.VirtualMachineInstanceSpec{
 								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
 									Devices: kubevirtv1.Devices{
 										Disks: []kubevirtv1.Disk{
 											{Name: "disk0"},
@@ -2683,8 +2833,9 @@ func TestHandleVMUpdate(t *testing.T) {
 				}
 				mockClient.AddVMI(vmi)
 			},
-			expectRestore:    false,
-			expectClearState: false,
+			expectRestore:        false,
+			expectClearState:     false,
+			expectedRebootPolicy: &terminate,
 		},
 		{
 			name: "VM was off, now has VMI - should restore",
@@ -2699,6 +2850,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Annotations: map[string]string{
 							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":1}]`,
 							BootOnceVMIUIDAnnotation:               "", // Was off
+							BootOnceOriginalRebootPolicyAnnotation: "Reboot",
 							"redfish.boot.source.override.enabled": "Once",
 						},
 					},
@@ -2706,6 +2858,7 @@ func TestHandleVMUpdate(t *testing.T) {
 						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: kubevirtv1.VirtualMachineInstanceSpec{
 								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
 									Devices: kubevirtv1.Devices{
 										Disks: []kubevirtv1.Disk{
 											{Name: "disk0"},
@@ -2733,6 +2886,10 @@ func TestHandleVMUpdate(t *testing.T) {
 			},
 			expectRestore:    true,
 			expectClearState: true,
+			expectedRebootPolicy: func() *kubevirtv1.RebootPolicy {
+				p := kubevirtv1.RebootPolicyReboot
+				return &p
+			}(),
 		},
 	}
 
@@ -2773,10 +2930,29 @@ func TestHandleVMUpdate(t *testing.T) {
 				if annotations[BootOnceOriginalConfigAnnotation] != "" {
 					t.Errorf("Expected original config annotation to be removed")
 				}
+				if annotations[BootOnceOriginalRebootPolicyAnnotation] != "" {
+					t.Errorf("Expected original reboot policy annotation to be removed, got '%s'", annotations[BootOnceOriginalRebootPolicyAnnotation])
+				}
 			} else {
 				// Boot-once label should still be present
 				if labels[BootOnceLabel] != "enabled" {
 					t.Errorf("Expected boot-once label to be 'enabled', got '%s'", labels[BootOnceLabel])
+				}
+			}
+
+			var actualPolicy *kubevirtv1.RebootPolicy
+			if updatedVM.Spec.Template != nil {
+				actualPolicy = updatedVM.Spec.Template.Spec.Domain.RebootPolicy
+			}
+			if tc.expectedRebootPolicy == nil {
+				if actualPolicy != nil {
+					t.Errorf("Expected rebootPolicy to be nil, got '%s'", *actualPolicy)
+				}
+			} else {
+				if actualPolicy == nil {
+					t.Errorf("Expected rebootPolicy '%s', got nil", *tc.expectedRebootPolicy)
+				} else if *actualPolicy != *tc.expectedRebootPolicy {
+					t.Errorf("Expected rebootPolicy '%s', got '%s'", *tc.expectedRebootPolicy, *actualPolicy)
 				}
 			}
 		})

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -2052,6 +2052,200 @@ func uintPtr(v uint) *uint {
 	return &v
 }
 
+// TestSetBootOrderClearsBootOnceState verifies that a permanent boot order
+// change removes any pending boot-once annotations, label, and restores the
+// original rebootPolicy.
+func TestSetBootOrderClearsBootOnceState(t *testing.T) {
+	terminate := kubevirtv1.RebootPolicyTerminate
+	reboot := kubevirtv1.RebootPolicyReboot
+
+	testCases := []struct {
+		name                 string
+		bootTarget           string
+		setupVM              func(mockClient *MockDynamicClient)
+		expectedRebootPolicy *kubevirtv1.RebootPolicy
+	}{
+		{
+			name:       "Permanent boot order clears boot-once state and restores rebootPolicy",
+			bootTarget: "Hdd",
+			setupVM: func(mockClient *MockDynamicClient) {
+				bootOrder1 := uint(1)
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							BootOnceLabel: "enabled",
+						},
+						Annotations: map[string]string{
+							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":2},{"diskName":"cdrom0","bootOrder":1}]`,
+							BootOnceVMIUIDAnnotation:               "some-vmi-uid",
+							BootOnceOriginalRebootPolicyAnnotation: "Reboot",
+							"redfish.boot.source.override.enabled": "Once",
+							"redfish.boot.source.override.target":  "Cd",
+							"redfish.boot.source.override.mode":    "UEFI",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
+									Devices: kubevirtv1.Devices{
+										Disks: []kubevirtv1.Disk{
+											{Name: "disk0", BootOrder: &bootOrder1},
+											{Name: "cdrom0"},
+										},
+									},
+								},
+								Volumes: []kubevirtv1.Volume{
+									{Name: "disk0", VolumeSource: kubevirtv1.VolumeSource{DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv0"}}},
+									{Name: "cdrom0"},
+								},
+							},
+						},
+					},
+				}
+				mockClient.AddVM(vm)
+			},
+			expectedRebootPolicy: &reboot,
+		},
+		{
+			name:       "Permanent boot order on VM without boot-once is a no-op for annotations",
+			bootTarget: "Hdd",
+			setupVM: func(mockClient *MockDynamicClient) {
+				bootOrder1 := uint(1)
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									Devices: kubevirtv1.Devices{
+										Disks: []kubevirtv1.Disk{
+											{Name: "disk0", BootOrder: &bootOrder1},
+											{Name: "cdrom0"},
+										},
+									},
+								},
+								Volumes: []kubevirtv1.Volume{
+									{Name: "disk0", VolumeSource: kubevirtv1.VolumeSource{DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv0"}}},
+									{Name: "cdrom0"},
+								},
+							},
+						},
+					},
+				}
+				mockClient.AddVM(vm)
+			},
+			expectedRebootPolicy: nil,
+		},
+		{
+			name:       "Permanent boot order clears boot-once with no original rebootPolicy",
+			bootTarget: "Cd",
+			setupVM: func(mockClient *MockDynamicClient) {
+				bootOrder1 := uint(1)
+				vm := &kubevirtv1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vm",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							BootOnceLabel: "enabled",
+						},
+						Annotations: map[string]string{
+							BootOnceOriginalConfigAnnotation:       `[{"diskName":"disk0","bootOrder":1}]`,
+							BootOnceVMIUIDAnnotation:               "some-vmi-uid",
+							BootOnceOriginalRebootPolicyAnnotation: "",
+							"redfish.boot.source.override.enabled": "Once",
+							"redfish.boot.source.override.target":  "Cd",
+						},
+					},
+					Spec: kubevirtv1.VirtualMachineSpec{
+						Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+							Spec: kubevirtv1.VirtualMachineInstanceSpec{
+								Domain: kubevirtv1.DomainSpec{
+									RebootPolicy: &terminate,
+									Devices: kubevirtv1.Devices{
+										Disks: []kubevirtv1.Disk{
+											{Name: "disk0", BootOrder: &bootOrder1},
+											{Name: "cdrom0"},
+										},
+									},
+								},
+								Volumes: []kubevirtv1.Volume{
+									{Name: "disk0", VolumeSource: kubevirtv1.VolumeSource{DataVolume: &kubevirtv1.DataVolumeSource{Name: "dv0"}}},
+									{Name: "cdrom0"},
+								},
+							},
+						},
+					},
+				}
+				mockClient.AddVM(vm)
+			},
+			expectedRebootPolicy: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDynamicClient := NewMockDynamicClient()
+			fakeK8sClient := fake.NewSimpleClientset()
+
+			tc.setupVM(mockDynamicClient)
+
+			client := NewClientWithClients(fakeK8sClient, mockDynamicClient, 30*time.Second, nil)
+
+			err := client.SetBootOrder("test-namespace", "test-vm", tc.bootTarget)
+			if err != nil {
+				t.Fatalf("SetBootOrder failed: %v", err)
+			}
+
+			vm, err := mockDynamicClient.GetVM("test-namespace", "test-vm")
+			if err != nil {
+				t.Fatalf("Failed to get VM: %v", err)
+			}
+
+			labels := vm.GetLabels()
+			if labels[BootOnceLabel] != "" {
+				t.Errorf("Expected boot-once label to be removed, got '%s'", labels[BootOnceLabel])
+			}
+
+			annotations := vm.GetAnnotations()
+			for _, key := range []string{
+				BootOnceOriginalConfigAnnotation,
+				BootOnceVMIUIDAnnotation,
+				BootOnceOriginalRebootPolicyAnnotation,
+				"redfish.boot.source.override.enabled",
+				"redfish.boot.source.override.target",
+				"redfish.boot.source.override.mode",
+			} {
+				if annotations[key] != "" {
+					t.Errorf("Expected annotation %s to be removed, got '%s'", key, annotations[key])
+				}
+			}
+
+			var actualPolicy *kubevirtv1.RebootPolicy
+			if vm.Spec.Template != nil {
+				actualPolicy = vm.Spec.Template.Spec.Domain.RebootPolicy
+			}
+			if tc.expectedRebootPolicy == nil {
+				if actualPolicy != nil {
+					t.Errorf("Expected rebootPolicy to be nil, got '%s'", *actualPolicy)
+				}
+			} else {
+				if actualPolicy == nil {
+					t.Errorf("Expected rebootPolicy '%s', got nil", *tc.expectedRebootPolicy)
+				} else if *actualPolicy != *tc.expectedRebootPolicy {
+					t.Errorf("Expected rebootPolicy '%s', got '%s'", *tc.expectedRebootPolicy, *actualPolicy)
+				}
+			}
+		})
+	}
+}
+
 // TestSetBootOnceLogic tests the SetBootOnce function logic in isolation
 func TestSetBootOnceLogic(t *testing.T) {
 	// Test cases for boot once logic


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This removes the burden of setting RebootPolicy to the proper value from the user. The update automatically manages RebootPolicy when the boot order commands are processed by the redfish controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [-] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [-] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [-] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The redfish controller now automatically manages the VM's RebootPolicy so the user does not have to.
```
