### PR TITLE
Synchronize the Go version in the Dockerfile with go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM docker.io/library/golang:1.24-alpine AS builder
+FROM docker.io/library/golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the Golang version in the Dockerfile to match the go.mod file in order to fix image build:

```
[1/2] STEP 5/7: RUN go mod download
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
Error: building at STEP "RUN go mod download": while running runtime: exit status 1
make: *** [Makefile:75: build-image] Error 1
```

**Special notes for your reviewer**:

/cc @MarSik

**Release note**:
```release-note
NONE
```
