### PR TITLE
fix(client): helper pod OOMKill when downloading ISO

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -2028,7 +2028,6 @@ func (c *Client) copyISOToPVC(namespace, dataVolumeName, imageURL, isoDownloadTi
 	}
 
 	pvcName := dataVolumeName
-	isoFileName := filepath.Base(imageURL)
 
 	timestamp := time.Now().Unix()
 	helperPodName := sanitizeResourceName(fmt.Sprintf("copy-iso-%s-%d", dataVolumeName, timestamp))
@@ -2066,7 +2065,7 @@ func (c *Client) copyISOToPVC(namespace, dataVolumeName, imageURL, isoDownloadTi
 				"cpu":    resourceMustParse("50m"),
 			},
 			Limits: corev1.ResourceList{
-				"memory": resourceMustParse("512Mi"),
+				"memory": resourceMustParse("1024Mi"),
 				"cpu":    resourceMustParse("250m"),
 			},
 		},
@@ -2075,15 +2074,15 @@ func (c *Client) copyISOToPVC(namespace, dataVolumeName, imageURL, isoDownloadTi
 	if isBlock {
 		logger.Info("PVC %s uses Block volume mode, helper pod will use dd", pvcName)
 		container.Command = []string{"sh", "-c", fmt.Sprintf(
-			"curl --fail --show-error --insecure --connect-timeout 30 --max-time 1800 --location -o /tmp/%s %s && [ -s /tmp/%s ] && dd if=/tmp/%s of=/dev/block bs=1M conv=fsync",
-			isoFileName, imageURL, isoFileName, isoFileName)}
+			"set -o pipefail; curl --fail --show-error --insecure --connect-timeout 30 --max-time 1800 --location %s | dd of=/dev/block bs=1M oflag=direct conv=fsync",
+			imageURL)}
 		container.VolumeDevices = []corev1.VolumeDevice{
 			{Name: "iso-volume", DevicePath: "/dev/block"},
 		}
 	} else {
 		logger.Info("PVC %s uses Filesystem volume mode, helper pod will download directly", pvcName)
 		container.Command = []string{"sh", "-c", fmt.Sprintf(
-			"curl --fail --show-error --insecure --connect-timeout 30 --max-time 1800 --location -o /mnt/iso/disk.img %s && [ -s /mnt/iso/disk.img ] && sync /mnt/iso/disk.img",
+			"set -o pipefail; curl --fail --show-error --insecure --connect-timeout 30 --max-time 1800 --location %s | dd of=/mnt/iso/disk.img bs=1M oflag=direct conv=fsync",
 			imageURL)}
 		container.VolumeMounts = []corev1.VolumeMount{
 			{Name: "iso-volume", MountPath: "/mnt/iso"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The copy-iso helper pods were OOMKilled when downloading ISOs to NFS PVCs. the kernel dirty page cache filled the 512Mi cgroup mem limit before NFS could flush, triggering the OOM killer

This caused the importing labels to be removed before ironic's power-on request arrived. The VMs booted with truncated ISOs on the CD-ROM, fell through to HDD boot, and introspection timed out.

- Raise mem limit from 1024Mi for headroom across storage flush
- Filesystem mode: Avoid page cache by using dd oflag=direct
- Block mode: Replace /tmp intermediate file with direct pipe to stream
  to the block device

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDktMDJUMTY6NDQ6NDR8M2MwMmY5OTFhMmExNzg3MDI5OTE5MjYxNmMwOTVmMmZmNDk0ZmU0ZQ==
Gitleaks-Hash: 5d4f0b5d7bba97d571a9817a4ef825b659095456fa37721583e8a9e95beff98f

Fixes #18 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
**Fixed** helper pod OOM crash during VirtualMedia ISO import on Filesystem-backed
storage. ISO downloads to NFS or other filesystem PVCs caused the helper pod to be
OOMKilled due to kernel page cache pressure exceeding the memory limit (512Mi).
This resulted in silent import failures.
- Increase memory pod limit to 1024Mi
- Filesystem mode: Avoid page cache by using dd oflag=direct
- Block mode: Direct download to block device.
```
